### PR TITLE
feat(user, join-requests): implement user join request tracking and g…

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -35,6 +35,8 @@ export const register = async (req, res, next) => {
       password: hashedPassword,
       whatsappNumber,
       token: hashedToken, // Store the hashed token
+      joinRequests: [], 
+      groups: [], 
       createdAt: Date.now(),
       expiresAt: Date.now() + 3600000, // 1 hour expiry for the token
     });
@@ -57,6 +59,8 @@ export const register = async (req, res, next) => {
     return res.status(500).json({ message: "Server error. Try again later." });
   }
 };
+
+// Verify email
 export const verifyEmail = async (req, res) => {
   const { token } = req.params; // Get the token from the URL
 
@@ -84,7 +88,7 @@ export const verifyEmail = async (req, res) => {
     }
 
     // Create the user now that the email is verified
-    const { firstName, lastName, email, password, whatsappNumber } =
+    const { firstName, lastName, email, password, whatsappNumber, joinRequests, groups } =
       verificationRecord;
 
     const user = await Users.create({
@@ -94,6 +98,8 @@ export const verifyEmail = async (req, res) => {
       password, // Password is already hashed
       whatsappNumber,
       verified: true,
+      joinRequests: [], // Initialize as an empty array
+      groups: [], 
     });
 
     // Delete the verification record after user creation
@@ -109,6 +115,9 @@ export const verifyEmail = async (req, res) => {
     res.status(500).json({ message: "Server error. Try again later." });
   }
 };
+
+
+// Login user
 export const login = async (req, res, next) => {
   const { email, password } = req.body;
   // Validation

--- a/server/models/emailVerification.js
+++ b/server/models/emailVerification.js
@@ -7,6 +7,8 @@ const emailVerificationSchema = new mongoose.Schema({
   password: { type: String, required: true },
   whatsappNumber: { type: String, required: true },
   token: { type: String, required: true },
+  JoinRequests: [],
+  groups: [],
   createdAt: { type: Date, required: true },
   expiresAt: { type: Date, required: true },
 });

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -1,6 +1,6 @@
 import mongoose, { Schema } from "mongoose";
 
-//schema
+// User schema
 const userSchema = new mongoose.Schema(
   {
     firstName: {
@@ -13,13 +13,13 @@ const userSchema = new mongoose.Schema(
     },
     email: {
       type: String,
-      required: [true, " Email is Required!"],
+      required: [true, "Email is Required!"],
       unique: true,
     },
     password: {
       type: String,
       required: [true, "Password is Required!"],
-      minlength: [6, "Password length should be greater than 6 character"],
+      minlength: [6, "Password length should be greater than 6 characters"],
       select: true,
     },
     location: { type: String },
@@ -29,7 +29,17 @@ const userSchema = new mongoose.Schema(
     views: [{ type: String }],
     verified: { type: Boolean, default: false },
     whatsappNumber: { type: String, required: true },
-    groups: [{ type: Schema.Types.ObjectId, ref: "Groups" }], // Assuming a separate Group model for chat groups
+    groups: [{ type: Schema.Types.ObjectId, ref: "Groups" }],
+    joinRequests: [
+      {
+        postId: { type: Schema.Types.ObjectId, ref: "Posts" }, // Reference to the post
+        status: {
+          type: String,
+          enum: ["Pending", "Accepted", "Rejected"], // Status of the join request
+          default: "Pending",
+        },
+      },
+    ],
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## _feat(user, join-requests):_ implement user join request tracking and group creation

- Added `joinRequests` and `groups` fields to the `User` schema to track join request history and group memberships.
- Updated `createJoinRequest` controller to check for existing requests in the user’s `joinRequests` array.
- Implemented logic in `acceptJoinRequest` controller to create a group for the post if it doesn’t exist, and update both user and post models with the group reference.
- Ensured that the `joinRequests` schema removes the request after processing (accepted/rejected).
- Initialized `joinRequests` and `groups` arrays in the user creation process.
